### PR TITLE
Hide deactivated widgets for all user roles except Admin

### DIFF
--- a/elementor-widget-manager.php
+++ b/elementor-widget-manager.php
@@ -275,7 +275,7 @@ final class Elementor_Widget_Manager {
 
 		$selected_widgets = get_option( 'ewm_widget' );
 
-		if ( ! empty( $selected_widgets ) ) {
+		if ( ! empty( $selected_widgets &&  !current_user_can('activate_plugins')) ) {
 			foreach ( $selected_widgets as $widget ) {
 				$elementor->widgets_manager->unregister_widget_type( $widget );
 			}


### PR DESCRIPTION
This PR sets it so that the function to deactivate widgets only runs with users with privileges below Admin. This was done by using a user permission that only admin roles have in all of our instances (activate_plugins) to check whether the user is an admin or not. If the current user is an admin, they will continue to see all elementor widgets. If they are anything other than administrator, they will see only those active widgets.

For this plugin to work properly, we have to have no boxes checked for custom roles under the Elementor > Role Manager, with the exception of Non-Staff, which should continue to have no access to edit content.